### PR TITLE
[BST-6784] Updated bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,4 +224,4 @@ RUBY VERSION
    ruby 3.1.1p18
 
 BUNDLED WITH
-   2.3.7
+   2.3.10


### PR DESCRIPTION
Updated `BUNDLED WITH` to 2.3.10 to keep in line with other Boxt projects.