### PR TITLE
[N/A] Enforce descriptions when examples are multi-line

### DIFF
--- a/rspec.yml
+++ b/rspec.yml
@@ -25,4 +25,6 @@ RSpec/MultipleMemoizedHelpers:
 RSpec/NestedGroups:
   Max: 4
 
-
+# Multi-line examples must have a description
+RSpec/ExampleWithoutDescription:
+  EnforcedStyle: single_line_only


### PR DESCRIPTION
Updates our default RSpec config to enforce example descriptions for multi-line examples. Follows a style discussion in https://github.com/boxt/boxt-mono/issues/6379

```
# bad
it do
  result = service.call
  expect(result).to be(true)
end

# good
it { is_expected.to be_good }

it "does a thing because of a reason" do
  expect(thing).to be_done
end
```