### PR TITLE
Updated how to require version file to fix Dependabot updates

### DIFF
--- a/boxt_rubocop.gemspec
+++ b/boxt_rubocop.gemspec
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "lib/rubocop/boxt/version"
+lib = File.expand_path("lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "rubocop/boxt/version"
 
 Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.0"


### PR DESCRIPTION
Now using the same require as other Boxt gems which also sets the `$LOAD_PATH`.

This is to hopefully resolve:

<img width="906" alt="Screenshot 2024-01-23 at 09 50 33" src="https://github.com/boxt/boxt_rubocop/assets/163900/8a5bec47-aaad-4958-9334-087b778911cf">
