### PR TITLE
Update RSpec ExampleLength CountAsOne config to include method calls

### DIFF
--- a/rspec.yml
+++ b/rspec.yml
@@ -14,8 +14,9 @@ RSpec/LeadingSubject:
     - spec/support
 
 # Allow arrays and hashes to be counted as one line in examples
+# Also considers arrays defined with contain_exactly and match_array
 RSpec/ExampleLength:
-  CountAsOne: ["array", "hash"]
+  CountAsOne: ["array", "hash", "contain_exactly", "match_array"]
 
 # Because 5 is a bit mean
 RSpec/MultipleMemoizedHelpers:

--- a/rspec.yml
+++ b/rspec.yml
@@ -13,10 +13,9 @@ RSpec/LeadingSubject:
   Exclude:
     - spec/support
 
-# Allow arrays and hashes to be counted as one line in examples
-# Also considers arrays defined with contain_exactly and match_array
+# Allow arrays, hashes, and method calls to be counted as one line in examples
 RSpec/ExampleLength:
-  CountAsOne: ["array", "hash", "contain_exactly", "match_array"]
+  CountAsOne: ["array", "hash", "method_call"]
 
 # Because 5 is a bit mean
 RSpec/MultipleMemoizedHelpers:


### PR DESCRIPTION
The CountAsOne config for the RSpec/ExampleLength offence has the option to consider method calls as a single line

See https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleLength

This allows us to write expectations using `contain_exactly` without triggering the example length offence.

The following currently triggers an RSpec/ExampleLength offence which would be resolved by adding `method_call` to the CountAsOne config

```
    it "does something that we are checking with contain_exactly" do
      expect(object_returning_array).to contain_exactly(
          have_attributes(attribute: "value", count: 5),
          have_attributes(attribute: "value", count: 5),
          have_attributes(attribute: "value", count: 5),
          have_attributes(attribute: "value", count: 5),
          have_attributes(attribute: "value", count: 5)
      )
    end
```