### PR TITLE
Add api_type_parameters cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,8 @@ AllCops:
 
 Rails/RakeEnvironment:
   Enabled: false
+
+# Disabling this as, due to how we test cops (i.e. with large code snippets),
+# the individual tests are always going to be a bit long.
+RSpec/ExampleLength:
+  Enabled: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -11,6 +11,10 @@ Boxt/ApiPathFormat:
   Description: 'Ensure that the API path uses kebab case'
   Enabled: false
 
+Boxt/ApiTypeParameters:
+  Description: 'Ensure that API parameters are typed'
+  Enabled: false
+
 Layout/ClassStructure:
   Enabled: true
 

--- a/lib/rubocop/cop/boxt/api_type_parameters.rb
+++ b/lib/rubocop/cop/boxt/api_type_parameters.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Boxt
+      # This cop ensures that each parameter in a Grape API has a type specified.
+      #
+      # @example
+      #   # bad
+      #   requires :name
+      #   optional :age
+      #
+      #   # good
+      #   requires :name, type: String
+      #   optional :age, type: Integer
+      #
+      class ApiTypeParameters < Cop
+        MSG = "Ensure each parameter has a type specified, e.g., `type: String`."
+
+        def_node_matcher :param_declaration, <<-PATTERN
+          (send nil? {:optional :requires} _ $...)
+        PATTERN
+
+        def on_send(node)
+          param_declaration(node) do |args|
+            next unless grape_api_class?(node)
+            next if type_specified?(args)
+
+            add_offense(node, message: MSG)
+          end
+        end
+
+        private
+
+        def grape_api_class?(node)
+          node.each_ancestor(:class).any? do |ancestor|
+            ancestor.children.any? do |child|
+              child&.source == "Grape::API"
+            end
+          end
+        end
+
+        def type_specified?(args)
+          return false if args.empty?
+
+          args.any? do |arg|
+            arg.type == :hash && arg.children.any? do |pair|
+              pair.type == :pair && pair.children[0].source == "type"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/boxt_cops.rb
+++ b/lib/rubocop/cop/boxt_cops.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require_relative "boxt/api_path_format"
+require_relative "boxt/api_type_parameters"

--- a/spec/rubocop/cop/boxt/api_path_format_spec.rb
+++ b/spec/rubocop/cop/boxt/api_path_format_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe RuboCop::Cop::Boxt::ApiPathFormat, :config do
     RUBY
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it "registers an offense when using get with a path that contains underscores" do
     expect_offense(<<~RUBY)
       class Test < Grape::API
@@ -69,7 +68,6 @@ RSpec.describe RuboCop::Cop::Boxt::ApiPathFormat, :config do
       end
     RUBY
   end
-  # rubocop:enable RSpec/ExampleLength
 
   it "does not register an offense when there is an underscore in the path parameter" do
     expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/boxt/api_type_parameters_spec.rb
+++ b/spec/rubocop/cop/boxt/api_type_parameters_spec.rb
@@ -1,47 +1,67 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/ExampleLength
 RSpec.describe RuboCop::Cop::Boxt::ApiTypeParameters, :config do
-  it "does not register an offense when required parameter has type set" do
-    expect_no_offenses(<<~RUBY)
-      class Test < Grape::API
-        params do
-          requires :name, type: String
+  context "when checking Grape::API parameters" do
+    it "does not register an offense when required parameter has type set" do
+      expect_no_offenses(<<~RUBY)
+        class Test < Grape::API
+          params do
+            requires :name, type: String
+          end
         end
-      end
-    RUBY
+      RUBY
+    end
+
+    it "does not register an offense when optional parameter has type set" do
+      expect_no_offenses(<<~RUBY)
+        class Test < Grape::API
+          params do
+            optional :age, type: Integer
+          end
+        end
+      RUBY
+    end
+
+    it "registers an offense when required parameter has no type set" do
+      expect_offense(<<~RUBY)
+        class Test < Grape::API
+          params do
+            requires :name
+            ^^^^^^^^^^^^^^ Ensure each parameter has a type specified, e.g., `type: String`.
+          end
+        end
+      RUBY
+    end
+
+    it "registers an offense when optional parameter has no type set" do
+      expect_offense(<<~RUBY)
+        class Test < Grape::API
+          params do
+            optional :age
+            ^^^^^^^^^^^^^ Ensure each parameter has a type specified, e.g., `type: String`.
+          end
+        end
+      RUBY
+    end
   end
 
-  it "does not register an offense when optional parameter has type set" do
-    expect_no_offenses(<<~RUBY)
-      class Test < Grape::API
-        params do
-          optional :age, type: Integer
+  context "when checking Grape::Entity parameters" do
+    it "does not register an offense when parameter has type set" do
+      expect_no_offenses(<<~RUBY)
+        class Test < Grape::Entity
+          expose :name, documentation: { type: String }
         end
-      end
-    RUBY
-  end
+      RUBY
+    end
 
-  it "registers an offense when required parameter has no type set" do
-    expect_offense(<<~RUBY)
-      class Test < Grape::API
-        params do
-          requires :name
-          ^^^^^^^^^^^^^^ Ensure each parameter has a type specified, e.g., `type: String`.
+    it "registers an offense when parameter has no type set" do
+      expect_offense(<<~RUBY)
+        class Test < Grape::Entity
+          expose :name
+          ^^^^^^^^^^^^ Ensure each parameter has a type specified, e.g., `documentation: { type: String }`.
         end
-      end
-    RUBY
-  end
-
-  it "registers an offense when optional parameter has no type set" do
-    expect_offense(<<~RUBY)
-      class Test < Grape::API
-        params do
-          optional :age
-          ^^^^^^^^^^^^^ Ensure each parameter has a type specified, e.g., `type: String`.
-        end
-      end
-    RUBY
+      RUBY
+    end
   end
 
   it "does not register an offense when the class isn't a Grape API" do
@@ -54,4 +74,3 @@ RSpec.describe RuboCop::Cop::Boxt::ApiTypeParameters, :config do
     RUBY
   end
 end
-# rubocop:enable RSpec/ExampleLength

--- a/spec/rubocop/cop/boxt/api_type_parameters_spec.rb
+++ b/spec/rubocop/cop/boxt/api_type_parameters_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/ExampleLength
+RSpec.describe RuboCop::Cop::Boxt::ApiTypeParameters, :config do
+  it "does not register an offense when required parameter has type set" do
+    expect_no_offenses(<<~RUBY)
+      class Test < Grape::API
+        params do
+          requires :name, type: String
+        end
+      end
+    RUBY
+  end
+
+  it "does not register an offense when optional parameter has type set" do
+    expect_no_offenses(<<~RUBY)
+      class Test < Grape::API
+        params do
+          optional :age, type: Integer
+        end
+      end
+    RUBY
+  end
+
+  it "registers an offense when required parameter has no type set" do
+    expect_offense(<<~RUBY)
+      class Test < Grape::API
+        params do
+          requires :name
+          ^^^^^^^^^^^^^^ Ensure each parameter has a type specified, e.g., `type: String`.
+        end
+      end
+    RUBY
+  end
+
+  it "registers an offense when optional parameter has no type set" do
+    expect_offense(<<~RUBY)
+      class Test < Grape::API
+        params do
+          optional :age
+          ^^^^^^^^^^^^^ Ensure each parameter has a type specified, e.g., `type: String`.
+        end
+      end
+    RUBY
+  end
+
+  it "does not register an offense when the class isn't a Grape API" do
+    expect_no_offenses(<<~RUBY)
+      class Test
+        params do
+          requires :name
+        end
+      end
+    RUBY
+  end
+end
+# rubocop:enable RSpec/ExampleLength


### PR DESCRIPTION
**Description:**

This adds a custom Rubocop cop that enforces the type attribute on all API parameters. I'll enable it for V2 and V3 of the API, as they're largely covered by types already, but will leave it disabled for V1 which isn't.

In addition to improving the documentation, one of the main reasons for adding this was so we could avoid an issue we had recently with some of the package endpoints where the type parameter had been configured incorrectly (e.g. `optional :foo, String` rather than `optional :foo, type: String`), and then other developers had copied this syntax and it had spread from there.