### PR TITLE
Fixes for the api-types-cop

### DIFF
--- a/lib/rubocop/cop/boxt/api_type_parameters.rb
+++ b/lib/rubocop/cop/boxt/api_type_parameters.rb
@@ -23,11 +23,11 @@ module RuboCop
         PATTERN
 
         def_node_search :param_with_type, <<-PATTERN
-          (send nil? {:optional :requires} _ (hash <(pair (sym :type) $_)>))
+          (send nil? {:optional :requires} _ (hash <(pair (sym :type) $_) ...>))
         PATTERN
 
         def_node_search :entity_with_type_documentation, <<-PATTERN
-          (send nil? :expose _ (hash <(pair (sym :documentation) (hash <(pair (sym :type) $_)>)) ...>))
+          (send nil? :expose _ (hash <(pair (sym :documentation) (hash <(pair (sym :type) $_) ...>)) ...>))
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/boxt/api_type_parameters_spec.rb
+++ b/spec/rubocop/cop/boxt/api_type_parameters_spec.rb
@@ -12,11 +12,31 @@ RSpec.describe RuboCop::Cop::Boxt::ApiTypeParameters, :config do
       RUBY
     end
 
+    it "does not register an offense when required parameter has type set alongside other parameters" do
+      expect_no_offenses(<<~RUBY)
+        class Test < Grape::API
+          params do
+            requires :name, type: String, foo: 123
+          end
+        end
+      RUBY
+    end
+
     it "does not register an offense when optional parameter has type set" do
       expect_no_offenses(<<~RUBY)
         class Test < Grape::API
           params do
             optional :age, type: Integer
+          end
+        end
+      RUBY
+    end
+
+    it "does not register an offense when optional parameter has type set alongside other parameters" do
+      expect_no_offenses(<<~RUBY)
+        class Test < Grape::API
+          params do
+            optional :age, type: Integer, foo: 123
           end
         end
       RUBY
@@ -50,6 +70,14 @@ RSpec.describe RuboCop::Cop::Boxt::ApiTypeParameters, :config do
       expect_no_offenses(<<~RUBY)
         class Test < Grape::Entity
           expose :name, documentation: { type: String }
+        end
+      RUBY
+    end
+
+    it "does not register an offense when parameter has type set alongside other parameters" do
+      expect_no_offenses(<<~RUBY)
+        class Test < Grape::Entity
+          expose :name, documentation: { type: String, desc: "some description" }, foo: 123
         end
       RUBY
     end


### PR DESCRIPTION
## Description

It was registering offences when there were any extra parameters in the parameter/entity calls. This fixes that and adds some extra specs.