### PR TITLE
Fix RuboCop::Cop::Cop dep warning

### DIFF
--- a/lib/rubocop/cop/boxt/api_path_format.rb
+++ b/lib/rubocop/cop/boxt/api_path_format.rb
@@ -23,7 +23,7 @@ module RuboCop
       #   get  "/installation-days"
       #   namespace "password-resets"
       #
-      class ApiPathFormat < Base
+      class ApiPathFormat < RuboCop::Cop::Base
         def_node_matcher :path_defining_method_with_string_path, <<~PATTERN
           (send nil? {:post | :get | :namespace} (:str $_))
         PATTERN

--- a/lib/rubocop/cop/boxt/api_type_parameters.rb
+++ b/lib/rubocop/cop/boxt/api_type_parameters.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   requires :name, type: String
       #   optional :age, type: Integer
       #
-      class ApiTypeParameters < Cop
+      class ApiTypeParameters < RuboCop::Cop::Base
         API_MESSAGE = "Ensure each parameter has a type specified, e.g., `type: String`."
         ENTITY_MESSAGE = "Ensure each parameter has a type specified, e.g., `documentation: { type: String }`."
 


### PR DESCRIPTION
Fixes:

```sh
Running bundle exec rubocop -a . in .github/workflows/danger 
/Users/stu/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/boxt_rubocop-2.14.0/lib/rubocop/cop/boxt/api_type_parameters.rb:17: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.
```