### PR TITLE
Remove rails call when debugging rubocop

### DIFF
--- a/lib/rubocop/boxt/inject.rb
+++ b/lib/rubocop/boxt/inject.rb
@@ -11,7 +11,12 @@ module RuboCop
         path = CONFIG_DEFAULT.to_s
         hash = ConfigLoader.send(:load_yaml_configuration, path)
         config = Config.new(hash, path).tap(&:make_excludes_absolute)
+
+        # Using Rails.logger here will cause an error.
+        # See https://github.com/boxt/boxt_rubocop/pull/187
+        # rubocop:disable Rails/Output
         puts "configuration from #{path}" if ConfigLoader.debug?
+        # rubocop:enable Rails/Output
         config = ConfigLoader.merge_with_default(config, path)
         ConfigLoader.instance_variable_set(:@default_configuration, config)
       end

--- a/lib/rubocop/boxt/inject.rb
+++ b/lib/rubocop/boxt/inject.rb
@@ -11,7 +11,7 @@ module RuboCop
         path = CONFIG_DEFAULT.to_s
         hash = ConfigLoader.send(:load_yaml_configuration, path)
         config = Config.new(hash, path).tap(&:make_excludes_absolute)
-        Rails.logger.debug { "configuration from #{path}" } if ConfigLoader.debug?
+        puts "configuration from #{path}" if ConfigLoader.debug?
         config = ConfigLoader.merge_with_default(config, path)
         ConfigLoader.instance_variable_set(:@default_configuration, config)
       end


### PR DESCRIPTION
Using Rails to log output when running rubocop --debug causes the following
error:

```term
vscode ➜ /workspaces/sena-api (BR-3873) $ rubocop --debug
For /workspaces/sena-api: configuration from /workspaces/sena-api/.rubocop.yml
configuration from
/home/vscode/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/boxt_rubocop-2.16.0/config/default.yml
uninitialized constant RuboCop::Boxt::Inject::Rails
/home/vscode/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/boxt_rubocop-2.16.0/lib/rubocop/boxt/inject.rb:14:in
'RuboCop::Boxt::Inject.defaults!'
/home/vscode/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/boxt_rubocop-2.16.0/lib/boxt_rubocop.rb:9:in
'<top (required)>'
```

To fix this, we can use the same code as rubocop itself uses to log the debug:
`puts`.
