### PR TITLE
[N/A] Check api path format against put, patch, delete, and options methods

### DIFF
--- a/lib/rubocop/cop/boxt/api_path_format.rb
+++ b/lib/rubocop/cop/boxt/api_path_format.rb
@@ -25,7 +25,7 @@ module RuboCop
       #
       class ApiPathFormat < RuboCop::Cop::Base
         def_node_matcher :path_defining_method_with_string_path, <<~PATTERN
-          (send nil? {:post | :get | :namespace} (:str $_))
+          (send nil? {:get | :post | :put | :patch | :delete | :namespace} (:str $_))
         PATTERN
 
         def_node_matcher :namespace_with_symbol, <<~PATTERN

--- a/spec/rubocop/cop/boxt/api_path_format_spec.rb
+++ b/spec/rubocop/cop/boxt/api_path_format_spec.rb
@@ -51,6 +51,33 @@ RSpec.describe RuboCop::Cop::Boxt::ApiPathFormat, :config do
     RUBY
   end
 
+  it "registers an offense when using put with a path that contains underscores" do
+    expect_offense(<<~RUBY)
+      class Test < Grape::API
+        put "path/snake_case"
+        ^^^^^^^^^^^^^^^^^^^^^ Use kebab-case for the API path
+      end
+    RUBY
+  end
+
+  it "registers an offense when using patch with a path that contains underscores" do
+    expect_offense(<<~RUBY)
+      class Test < Grape::API
+        patch "path/snake_case"
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use kebab-case for the API path
+      end
+    RUBY
+  end
+
+  it "registers an offense when using delete with a path that contains underscores" do
+    expect_offense(<<~RUBY)
+      class Test < Grape::API
+        delete "path/snake_case"
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use kebab-case for the API path
+      end
+    RUBY
+  end
+
   it "registers an offense when using namespace with a path that contains underscores" do
     expect_offense(<<~RUBY)
       class Test < Grape::API


### PR DESCRIPTION
The ApiPathFormat cop was previously only checking against `post`,`get`, and `namespace` methods.

This meant that invalid paths using `put`, `patch` or `delete` could get through.